### PR TITLE
Avoid crash when no app can open a note link

### DIFF
--- a/app/src/main/java/uk/openvk/android/legacy/core/activities/NoteActivity.java
+++ b/app/src/main/java/uk/openvk/android/legacy/core/activities/NoteActivity.java
@@ -20,6 +20,7 @@
 package uk.openvk.android.legacy.core.activities;
 
 import android.annotation.SuppressLint;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -112,7 +113,11 @@ public class NoteActivity extends NetworkActivity {
                     if(request.getUrl() != null) {
                         url = request.getUrl().toString();
                         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                        view.getContext().startActivity(intent);
+                        try {
+                            view.getContext().startActivity(intent);
+                        } catch (ActivityNotFoundException e) {
+                            Toast.makeText(view.getContext(), R.string.no_app_to_open_link, Toast.LENGTH_LONG).show();
+                        }
                     }
                     return true;
                 }
@@ -123,7 +128,11 @@ public class NoteActivity extends NetworkActivity {
                 public boolean shouldOverrideUrlLoading(WebView view, String url) {
                     if(url != null) {
                         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                        view.getContext().startActivity(intent);
+                        try {
+                            view.getContext().startActivity(intent);
+                        } catch (ActivityNotFoundException e) {
+                            Toast.makeText(view.getContext(), R.string.no_app_to_open_link, Toast.LENGTH_LONG).show();
+                        }
                     }
                     return true;
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -748,4 +748,5 @@
     	<i><a href="openvk://notes/xhtml">Something</a> from (X)HTML supported.</i>
     ]]></string>
     <string name="sett_behavior">Behavior</string>
+    <string name="no_app_to_open_link">No app found to open this link</string>
 </resources>


### PR DESCRIPTION
`NoteActivity.forceBrowserForExternalLinks` opens note links with `startActivity` and no guard, in both the modern and the legacy `shouldOverrideUrlLoading`. On a device with no matching app this throws `ActivityNotFoundException` and crashes the app.

This wraps both launches in a try/catch and shows a short message when nothing can open the link. Links still open in their app when one is available.

Closes #204
